### PR TITLE
Microsoft Vendor Specific Attributes - unicodedecode error fix

### DIFF
--- a/src/modules/rlm_python3/rlm_python3.c
+++ b/src/modules/rlm_python3/rlm_python3.c
@@ -417,9 +417,21 @@ static int mod_populate_vptuple(PyObject *pPair, VALUE_PAIR *vp)
 	if (pStr == NULL) {
 		ERROR("%s:%d, vp->da->name: %s", __func__, __LINE__, vp->da->name);
 		if (PyErr_Occurred()) {
-			python_error_log();
+			if (PyErr_ExceptionMatches(PyExc_UnicodeDecodeError)) {
+				python_error_log();
+	    		pStr = PyBytes_FromString(buf);
+	    		if (pStr == NULL) {
+	        		ERROR("%s:%d, vp->da->name: %s", __func__, __LINE__, vp->da->name);
+					if (PyErr_Occurred()) {
+						python_error_log();
+					}
+					return -1;
+				}
+            } else {
+				python_error_log();
+				return -1;
+			}
 		}
-		return -1;
 	}
 
 	PyTuple_SET_ITEM(pPair, 1, pStr);

--- a/src/modules/rlm_python3/rlm_python3.c
+++ b/src/modules/rlm_python3/rlm_python3.c
@@ -415,9 +415,9 @@ static int mod_populate_vptuple(PyObject *pPair, VALUE_PAIR *vp)
 	pStr = PyUnicode_FromString(buf);
 
 	if (pStr == NULL) {
-		ERROR("%s:%d, vp->da->name: %s", __func__, __LINE__, vp->da->name);
 		if (PyErr_Occurred()) {
 			if (PyErr_ExceptionMatches(PyExc_UnicodeDecodeError)) {
+				DEBUG("Conversion to Unicode failed, returning %s as bytes", vp->da->name);
 				PyErr_Clear();
 				pStr = PyBytes_FromString(buf);
 				if (pStr == NULL) {
@@ -428,6 +428,7 @@ static int mod_populate_vptuple(PyObject *pPair, VALUE_PAIR *vp)
 					return -1;
 				}
 			} else {
+				ERROR("%s:%d, vp->da->name: %s", __func__, __LINE__, vp->da->name);
 				python_error_log();
 				return -1;
 			}

--- a/src/modules/rlm_python3/rlm_python3.c
+++ b/src/modules/rlm_python3/rlm_python3.c
@@ -419,15 +419,15 @@ static int mod_populate_vptuple(PyObject *pPair, VALUE_PAIR *vp)
 		if (PyErr_Occurred()) {
 			if (PyErr_ExceptionMatches(PyExc_UnicodeDecodeError)) {
 				python_error_log();
-	    		pStr = PyBytes_FromString(buf);
-	    		if (pStr == NULL) {
-	        		ERROR("%s:%d, vp->da->name: %s", __func__, __LINE__, vp->da->name);
+				pStr = PyBytes_FromString(buf);
+				if (pStr == NULL) {
+					ERROR("%s:%d, vp->da->name: %s", __func__, __LINE__, vp->da->name);
 					if (PyErr_Occurred()) {
 						python_error_log();
 					}
 					return -1;
 				}
-            } else {
+			} else {
 				python_error_log();
 				return -1;
 			}

--- a/src/modules/rlm_python3/rlm_python3.c
+++ b/src/modules/rlm_python3/rlm_python3.c
@@ -418,7 +418,7 @@ static int mod_populate_vptuple(PyObject *pPair, VALUE_PAIR *vp)
 		ERROR("%s:%d, vp->da->name: %s", __func__, __LINE__, vp->da->name);
 		if (PyErr_Occurred()) {
 			if (PyErr_ExceptionMatches(PyExc_UnicodeDecodeError)) {
-				python_error_log();
+				PyErr_Clear();
 				pStr = PyBytes_FromString(buf);
 				if (pStr == NULL) {
 					ERROR("%s:%d, vp->da->name: %s", __func__, __LINE__, vp->da->name);


### PR DESCRIPTION
Fix for `microsoft vendor specific attributes`, where value is not utf-8 string.

Testing:

Reproduced and tested on local setup.

