### PR TITLE
Avoid FreeRADIUS crashes when OCSP URL is bad URL

### DIFF
--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -2691,7 +2691,7 @@ static ocsp_status_t ocsp_check(REQUEST *request, X509_STORE *store, X509 *issue
 		switch (ret) {
 		case -1:
 			RWDEBUG("(TLS) ocsp: Invalid URL in certificate.  Not doing OCSP");
-			break;
+			goto skipped;
 
 		case 0:
 			if (conf->ocsp_url) {


### PR DESCRIPTION
## Description of the change
To avoid FreeRADIUS crashes when OCSP URL within certificates is bad URL (e.g. htp://localhost:2560)



When the URL is invalid, it will break
https://github.com/foxpass/freeradius-server/blob/9ee486a115cde20316ee10c60506359a0425c7d1/src/main/tls.c#L2690-L2694

And then continue executing the following logic
Because either host or port might be null, calculating strlen will cause a crash
https://github.com/foxpass/freeradius-server/blob/9ee486a115cde20316ee10c60506359a0425c7d1/src/main/tls.c#L2709-L2715

I think we should change break to goto skipped.
Then, based on the value of softfail, decide whether to accept or reject.

## Type of change
- [ ] Bug fix
- [ ] New feature

### Testing

- [ ] Testing information has been added - test cases checklist and steps followed for testing.
- [ ] Testing screenshot(s) attached for more information.

## Security

- [ ] This PR has security related considerations.
